### PR TITLE
Add `phpsploit` (C2 framework via PHP oneliner)

### DIFF
--- a/3.Exploitation-Tools/README.md
+++ b/3.Exploitation-Tools/README.md
@@ -114,6 +114,7 @@
 * [Kadabra](https://github.com/D35m0nd142/Kadabra) - Automatic LFI exploiter and scanner
 * [Kadimus](https://github.com/P0cL4bs/Kadimus) - LFI scan and exploit tool
 * [liffy](https://github.com/hvqzao/liffy) - LFI exploitation tool
+* [PhpSploit](https://github.com/nil0x42/phpsploit) - Full-featured C2 framework which silently persists on webserver via evil PHP oneliner
 
 ## Hex Editors
 * [HexEdit.js](https://hexed.it) - Browser-based hex editing


### PR DESCRIPTION
Add phpsploit tool (https://github.com/nil0x42/phpsploit):
Full-featured C2 framework which silently persists on webserver via evil PHP oneliner, with a complete asrenal of post-exploitation & privesc features
Ask me if you have any question :+1: